### PR TITLE
added amd to env confit to fix eslint “define” is not defined. (no-un…

### DIFF
--- a/index.js
+++ b/index.js
@@ -7,7 +7,8 @@ module.exports = {
 	'env': {
 		'browser': true,
 		'es6': true,
-		'node': true
+		'node': true,
+		"amd": true
 	},
 
 	'plugins': [


### PR DESCRIPTION
some of our project use AMD pattern. when using define in js, we get eslint error

```
define([
  'jquery',
  'FormUtilities',
  'FormHandler',
], function($, FormUtilities, FormHandler) {

```
![image](https://user-images.githubusercontent.com/8970820/39475306-aef61604-4d4f-11e8-9144-8e2ee2944b9d.png)

this fix is to prevent it.