### PR TITLE
add rule for promise to be on newline

### DIFF
--- a/index.js
+++ b/index.js
@@ -48,6 +48,7 @@ module.exports = {
 		'keyword-spacing': ['error', { 'before': true, 'after': true }],
 		'new-cap': ['error', { 'newIsCap': true, 'capIsNew': false }],
 		'new-parens': 'error',
+		'newline-per-chained-call': ['error', { 'ignoreChainWithDepth': 2 }],
 		'no-array-constructor': 'error',
 		'no-caller': 'error',
 		'no-class-assign': 'error',

--- a/index.js
+++ b/index.js
@@ -48,7 +48,7 @@ module.exports = {
 		'keyword-spacing': ['error', { 'before': true, 'after': true }],
 		'new-cap': ['error', { 'newIsCap': true, 'capIsNew': false }],
 		'new-parens': 'error',
-		'newline-per-chained-call': ['error', { 'ignoreChainWithDepth': 2 }],
+		'newline-per-chained-call': 'error',
 		'no-array-constructor': 'error',
 		'no-caller': 'error',
 		'no-class-assign': 'error',

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@telegraph-engineering/eslint-config-telegraph",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "Telegraph Engineering config for eslint",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Added the 'newline-per-chained-call' rule to the eslint, which requires a newline after each call in a method chain.
https://eslint.org/docs/rules/newline-per-chained-call#require-a-newline-after-each-call-in-a-method-chain-newline-per-chained-call